### PR TITLE
Avoid duplicate search

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { ReferencesPlusTreeDataProvider } from './tree'
 import type { History, ReferenceData } from './types'
 import { resortHistory } from './utils'
 import { addConfigListener, getConfig } from './configuration'
+import { AreLocationsEqual } from './utils'
 
 export function activate(ext: ExtensionContext) {
   let index = 0
@@ -35,12 +36,17 @@ export function activate(ext: ExtensionContext) {
       commands.executeCommand('vscode.executeReferenceProvider', window.activeTextEditor.document.uri, window.activeTextEditor.selection.active).then(async (res: any) => {
         const locations = res as Location[]
 
+        for (let entry of history) {
+          if (AreLocationsEqual(entry[0].FirstLocation, locations[0])){
+            return;
+          }
+        }
+
         const referenceDataMap: ReferenceData = new Map()
         locations.forEach((item) => {
           const cache = referenceDataMap.get(item.uri.path)
           if (referenceDataMap.get(item.uri.path))
             cache?.push(item)
-
           else
             referenceDataMap.set(item.uri.path, [item])
         })
@@ -56,7 +62,7 @@ export function activate(ext: ExtensionContext) {
 
         index = history.size
 
-        history.set({ index: index++, text }, referenceDataMap)
+        history.set({ index: index++, text,FirstLocation: locations[0] }, referenceDataMap)
 
         commands.executeCommand(`${EXT_ID}.refresh`)
       })

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,21 @@ export function activate(ext: ExtensionContext) {
         const locations = res as Location[]
 
         for (let entry of history) {
-          if (areLocationsEqual(entry[0].firstLocation, locations[0])){
+          if (areLocationsEqual(entry[0].firstLocation, locations[0])) {
+
+            const rootItems = await rpTree.getChildren(void 0)
+            if (rootItems == null || rootItems.length === 0) {
+              window.showInformationMessage("error: rootItems is null or empty")
+              return
+            }
+            
+            for (const rootItem of rootItems) {
+              //  rootItem.label to object
+              const dupIndex = (entry[0].index + 1).toString()
+              if (typeof rootItem.label === 'object' && rootItem.label.label === dupIndex) {
+                window.showInformationMessage("The references have been added to the tree view.")
+              }
+            }
             return;
           }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { ReferencesPlusTreeDataProvider } from './tree'
 import type { History, ReferenceData } from './types'
 import { resortHistory } from './utils'
 import { addConfigListener, getConfig } from './configuration'
-import { AreLocationsEqual } from './utils'
+import { areLocationsEqual } from './utils'
 
 export function activate(ext: ExtensionContext) {
   let index = 0
@@ -37,7 +37,7 @@ export function activate(ext: ExtensionContext) {
         const locations = res as Location[]
 
         for (let entry of history) {
-          if (AreLocationsEqual(entry[0].FirstLocation, locations[0])){
+          if (areLocationsEqual(entry[0].firstLocation, locations[0])){
             return;
           }
         }
@@ -62,7 +62,7 @@ export function activate(ext: ExtensionContext) {
 
         index = history.size
 
-        history.set({ index: index++, text,FirstLocation: locations[0] }, referenceDataMap)
+        history.set({ index: index++, text,firstLocation: locations[0] }, referenceDataMap)
 
         commands.executeCommand(`${EXT_ID}.refresh`)
       })

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,6 @@ import type { Location } from 'vscode'
 
 export type ReferenceData = Map<string, Location[]>
 
-export interface HistoryKey { index: number; text: string }
+export interface HistoryKey { index: number; text: string ; FirstLocation: Location}
 
 export type History = Map<HistoryKey, ReferenceData>

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,6 @@ import type { Location } from 'vscode'
 
 export type ReferenceData = Map<string, Location[]>
 
-export interface HistoryKey { index: number; text: string ; FirstLocation: Location}
+export interface HistoryKey { index: number; text: string ; firstLocation: Location}
 
 export type History = Map<HistoryKey, ReferenceData>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,7 @@ export function resortHistory(history: History) {
     hisKey.index = index++
 }
 
-export function AreLocationsEqual(loc1: vscode.Location, loc2: vscode.Location) {
+export function areLocationsEqual(loc1: vscode.Location, loc2: vscode.Location) {
   if (loc1.uri.toString() !== loc2.uri.toString()) {
     return false;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,7 @@
 import { commands } from 'vscode'
 import type { History, HistoryKey } from './types'
+import * as vscode from 'vscode';
+
 
 export class ContextKey<T> {
   constructor(public name: string) {}
@@ -13,4 +15,16 @@ export function resortHistory(history: History) {
   let index = 0
   for (const hisKey of history.keys())
     hisKey.index = index++
+}
+
+export function AreLocationsEqual(loc1: vscode.Location, loc2: vscode.Location) {
+  if (loc1.uri.toString() !== loc2.uri.toString()) {
+    return false;
+  }
+
+  if (!loc1.range.isEqual(loc2.range)) {
+    return false;
+  }
+
+  return true;
 }


### PR DESCRIPTION
Do not search again when this data already exists.
When a second query is made on the same target, it currently just returns without doing anything. 
I am considering whether to add a blink effect to prompt users that "the current search target already exists".
You may refer to the effect in this video.

https://github.com/happiness86/references-plus/assets/25265788/1db0beb1-9b1e-4cbf-82d9-6774f1b844a5

