### PR TITLE
Fixes error when the casing of the disk letter was different

### DIFF
--- a/src/tree.ts
+++ b/src/tree.ts
@@ -33,8 +33,13 @@ export class ReferencesPlusTreeDataProvider implements TreeDataProvider<Referenc
       if ('referenceDataMap' in element && element.referenceDataMap) {
         for (const [filePath, loc] of element.referenceDataMap) {
           const basename = path.basename(filePath)
-          const prefix = workspace.getWorkspaceFolder(loc[0].uri)?.uri.path || ''
-          const description = filePath.split(prefix)[1].split(basename)[0].slice(0, -1)
+          const workspaceFolder = workspace.getWorkspaceFolder(loc[0].uri)?.uri.path
+          let description
+          if (workspaceFolder)
+            description = path.relative(workspaceFolder, filePath)
+          else
+            description = filePath
+          description = path.dirname(description)
 
           const id = [element._id, filePath] as [HistoryKey, string]
           contents.push(


### PR DESCRIPTION
Fix for #9. It seems that the casing of the disk letter was different for `filePath` and `prefix`. One was lowercase and one uppercase. The new code seems to work.